### PR TITLE
Fixed typo in Pod documentation.

### DIFF
--- a/lib/HTTP/Accept.pm
+++ b/lib/HTTP/Accept.pm
@@ -96,7 +96,7 @@ The given media types in the prioritized order.
   Header                            | Values
   ----------------------------------+----------------------------
   text/html, application/json;q=0.5 | text/html, application/json
-  application/json;q=0.5, text/html | text/html, application/*
+  application/json;q=0.5, text/html | text/html, application/json
   application/*;q=0.5, text/html    | text/html, application/*
   */*                               | */*
 


### PR DESCRIPTION
Fixed a small typo in the Pod documentation.

_[[Assigned by [pullrequest.club](https://pullrequest.club/)]]_